### PR TITLE
Update README.md and fix require-python in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ NOTE: This project does not involve using recent alternatives like [unsloth](htt
 
 ## Getting Started
 
+### Requirements
+
+- Python 3.10 or higher
+- CUDA 12.1 or higher
+- Compatible NVIDIA GPU (Ampere or higher)
+
 ### Install from Source
 
 To install scripts and package from the source, follow the commands below. It is recommended to use `venv` for creating a virtual environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tuner"
 version = "0.0.1"
 authors = [{name = "Keishi Ishihara", email = "keishi.ishihara17@gmail.com"}]
 readme = "README.md"
-requires-python = ">3.10.0"
+requires-python = ">=3.10.0"
 license = {file = "LICENSE"}
 classifiers = [
     "Private :: Do Not Upload",


### PR DESCRIPTION
This PR updates the README to include a "Requirements" section and corrects the `requires-python` specification in `pyproject.toml` to `">=3.10.0"`.
